### PR TITLE
fix: cast pg agg types

### DIFF
--- a/server/src/db/db.ts
+++ b/server/src/db/db.ts
@@ -1,9 +1,11 @@
 import { Kysely, PostgresDialect } from "kysely";
-import { Pool } from "pg";
+import { Pool, types } from "pg";
 
 import { config } from "../../config/config";
 import { logger } from "../logger";
 import { DB } from "./schema";
+
+types.setTypeParser(types.builtins.INT8, (val) => parseInt(val));
 
 const pool = new Pool({
   connectionString: config.PILOTAGE_POSTGRES_URI,


### PR DESCRIPTION
Transformations des bingInt en integer au niveau du driver pg.
Ça permet que les count, max, min, etc soient bien des nombres en sortie de requête