### PR TITLE
chore: Création de batchs pour l'import des données des fichiers

### DIFF
--- a/server/src/modules/import/usecases/importDispositifs/importDispositifs.usecase.ts
+++ b/server/src/modules/import/usecases/importDispositifs/importDispositifs.usecase.ts
@@ -18,6 +18,7 @@ export const [importDispositifs] = inject(dependencies, (deps) => async () => {
     async (item) => {
       const dispositif = toDispositif(item);
       await deps.createDispositif(dispositif);
-    }
+    },
+    { parallel: 20 }
   );
 });

--- a/server/src/modules/import/usecases/importFamillesMetiers/importFamillesMetiers.usecase.ts
+++ b/server/src/modules/import/usecases/importFamillesMetiers/importFamillesMetiers.usecase.ts
@@ -30,7 +30,8 @@ export const importFamillesMetiersFactory =
         countFamillesMetier++;
         process.stdout.write(`\r${countFamillesMetier}`);
         await createFamillesMetiers(data);
-      }
+      },
+      { parallel: 20 }
     );
 
     process.stdout.write(
@@ -58,7 +59,8 @@ export const importFamillesMetiersFactory =
         countOptionsBTS++;
         process.stdout.write(`\r${countOptionsBTS}`);
         await createFamillesMetiers(data);
-      }
+      },
+      { parallel: 20 }
     );
 
     process.stdout.write(
@@ -85,7 +87,8 @@ export const importFamillesMetiersFactory =
         countOptionsAnneeCommune++;
         process.stdout.write(`\r${countOptionsAnneeCommune}`);
         await createFamillesMetiers(data);
-      }
+      },
+      { parallel: 20 }
     );
 
     process.stdout.write(

--- a/server/src/modules/import/usecases/importNiveauxDiplome/importNiveauxDiplome.usecase.ts
+++ b/server/src/modules/import/usecases/importNiveauxDiplome/importNiveauxDiplome.usecase.ts
@@ -24,7 +24,8 @@ export const importNiveauxDiplomeFactory =
       async (nNiveauDiplome) => {
         const niveauDiplome = toNiveauDiplome({ nNiveauDiplome });
         await createNiveauDiplome(niveauDiplome);
-      }
+      },
+      { parallel: 20 }
     );
   };
 

--- a/server/src/modules/import/usecases/importRawFile/createRawDatas.dep.ts
+++ b/server/src/modules/import/usecases/importRawFile/createRawDatas.dep.ts
@@ -1,9 +1,11 @@
 import { kdb } from "../../../../db/db";
 
+type RawData = { type: string, data: JSON }
+
 export const createRawDatas = async ({
   data,
 }: {
-  data: { type: string; data: JSON }[];
+  data: Array<RawData>;
 }) => {
   return await kdb
     .insertInto("rawData")

--- a/server/src/modules/import/usecases/importRawFile/importRawFile.usecase.ts
+++ b/server/src/modules/import/usecases/importRawFile/importRawFile.usecase.ts
@@ -2,12 +2,16 @@ import { inject } from "injecti";
 import { Readable, Writable } from "stream";
 import { pipeline } from "stream/promises";
 
+import batchCreate from "../../utils/batchCreate";
 import { getStreamParser } from "../../utils/parse";
 import { createRawDatas } from "./createRawDatas.dep";
 import { deleteRawData } from "./deleteRawData.dep";
 
 export const [importRawFile, importRawFileFactory] = inject(
-  { createRawDatas, deleteRawData },
+  {
+    batch: batchCreate(createRawDatas),
+    deleteRawData
+  },
   (deps) =>
     async ({ fileStream, type }: { fileStream: Readable; type: string }) => {
       process.stdout.write(`Import des lignes du fichier ${type}...\n`);
@@ -19,7 +23,8 @@ export const [importRawFile, importRawFileFactory] = inject(
         fileStream,
         getStreamParser(),
         new Writable({
-          final: (callback) => {
+          final: async (callback) => {
+            await deps.batch.flush();
             console.log(
               `Import du fichier ${type} réussi (${count} lignes ajoutées)\n`
             );
@@ -27,7 +32,7 @@ export const [importRawFile, importRawFileFactory] = inject(
           },
           objectMode: true,
           write: async (line, _, callback) => {
-            await deps.createRawDatas({ data: [{ type, data: line }] });
+            await deps.batch.create({ data: { data: line, type } });
             count++;
             process.stdout.write(`Ajout de ${count} lignes\r`);
             callback();

--- a/server/src/modules/import/usecases/importRegions/importLieuxGeographiques.deps.ts
+++ b/server/src/modules/import/usecases/importRegions/importLieuxGeographiques.deps.ts
@@ -3,29 +3,49 @@ import { Insertable } from "kysely";
 import { DB, kdb } from "../../../../db/db";
 import { rawDataRepository } from "../../repositories/rawData.repository";
 
-const createRegion = async (region: Insertable<DB["region"]>) => {
+const createRegions = async ({ data }: { data: Array<Insertable<DB["region"]>> }) => {
   await kdb
     .insertInto("region")
-    .values(region)
-    .onConflict((oc) => oc.column("codeRegion").doUpdateSet(region))
+    .values(data)
+    .onConflict((oc) => 
+      oc.column("codeRegion").doUpdateSet(eb => ({
+        libelleRegion: eb.ref("excluded.codeRegion"),
+        codeRegion: eb.ref("excluded.codeRegion")
+      }))
+    )
     .execute();
 };
 
-const createAcademie = async (academie: Insertable<DB["academie"]>) => {
+const createAcademies = async ({ data }: { data: Array<Insertable<DB["academie"]>> }) => {
   await kdb
     .insertInto("academie")
-    .values(academie)
-    .onConflict((oc) => oc.column("codeAcademie").doUpdateSet(academie))
+    .values(data)
+    .onConflict((oc) => 
+      oc.column("codeAcademie").doUpdateSet(eb => {
+        return {
+          codeRegion: eb.ref("excluded.codeRegion"),
+          codeAcademie: eb.ref("excluded.codeAcademie"),
+          libelleAcademie: eb.ref("excluded.libelleAcademie")
+        }
+      })
+    )
     .execute();
 };
 
-const createDepartement = async (
-  departement: Insertable<DB["departement"]>
+const createDepartements = async (
+  { data }: { data: Array<Insertable<DB["departement"]>> }
 ) => {
   await kdb
     .insertInto("departement")
-    .values(departement)
-    .onConflict((oc) => oc.column("codeDepartement").doUpdateSet(departement))
+    .values(data)
+    .onConflict((oc) => 
+      oc.column("codeDepartement").doUpdateSet(eb => ({
+        codeRegion: eb.ref("excluded.codeRegion"),
+        codeAcademie: eb.ref("excluded.codeAcademie"),
+        codeDepartement: eb.ref("excluded.codeDepartement"),
+        libelleDepartement: eb.ref("excluded.libelleDepartement")
+      }))
+    )
     .execute();
 };
 
@@ -43,8 +63,8 @@ const findDepartementAcademieRegions = async ({
   });
 
 export const importRegionsDeps = {
-  createRegion,
-  createAcademie,
-  createDepartement,
+  createRegions,
+  createAcademies,
+  createDepartements,
   findDepartementAcademieRegions,
 };

--- a/server/src/modules/import/utils/batchCreate.ts
+++ b/server/src/modules/import/utils/batchCreate.ts
@@ -1,0 +1,48 @@
+import _ from "lodash";
+
+const DEFAULT_BATCH_SIZE = 1000
+
+type CreateFunction<D> = ({ data }: { data: Array<D> }) => unknown
+
+/**
+ * Memory batch factory from a createCallback.
+ * @param createCallback function to take data array and create in database
+ * @param batchSize default 1000
+ * @param allowDuplicates default false
+ * @returns object with two functions: create (take data as parameter, and add it to the batch if it's not already in there), and flush (flush the batch).
+ */
+export default function batchCreate<T>(
+  createCallback: CreateFunction<T>,
+  batchSize: number = DEFAULT_BATCH_SIZE,
+  allowDuplicates: boolean = false
+) {
+  const BATCH: T[] = []
+
+  async function create({ data }: { data: T }) {
+    if (!allowDuplicates) {
+      const index = BATCH.findIndex(d => _.isEqual(d, data))
+      if (index !== -1) {
+        BATCH[index] = data
+      }
+    } else {
+      BATCH.push(data)
+    }
+  
+    if (BATCH.length >= batchSize) {
+      await createCallback({ data: BATCH })
+      BATCH.length = 0
+    }
+  }
+
+  async function flush() {
+    if (BATCH.length) {
+      await createCallback({ data: BATCH })
+      BATCH.length = 0
+    }
+  }
+
+  return {
+    create,
+    flush
+  }
+}

--- a/server/src/modules/import/utils/streamIt.ts
+++ b/server/src/modules/import/utils/streamIt.ts
@@ -4,7 +4,8 @@ import { pipeline } from "stream/promises";
 export const streamIt = <T>(
   load: (count: number) => Promise<T[]>,
   write: (chunk: T, writeCount: number) => Promise<void>,
-  { parallel = 1 } = {}
+  { parallel = 1 } = {},
+  onFinal?: () => Promise<void>
 ) => {
   let count = 0;
 
@@ -38,6 +39,10 @@ export const streamIt = <T>(
 
       callback();
     },
+    final: async (callback) => {
+      await onFinal?.();
+      callback();
+    }
   });
 
   return pipeline(readable, writable);


### PR DESCRIPTION
Pour les imports de fichiers, voici la totalité des temps d'exécution : 

Avant (746885 millisecondes ~ 12 minutes 27 sec): 
<img width="441" alt="Screenshot 2024-01-31 at 15 53 14" src="https://github.com/mission-apprentissage/tjp-pilotage/assets/5200291/50b5286a-b641-4de1-9abd-54e7e86ef6cd">

Après (107780 millisecondes ~ 1 minutes 48 sec) : 
<img width="431" alt="Screenshot 2024-01-31 at 17 27 25" src="https://github.com/mission-apprentissage/tjp-pilotage/assets/5200291/e76c7f79-90eb-441a-b22a-0ce98e78b40e">


