### PR TITLE
fix: unification des parametres des requêtes pour les consoles

### DIFF
--- a/ui/app/(wrapped)/intentions/restitution/page.tsx
+++ b/ui/app/(wrapped)/intentions/restitution/page.tsx
@@ -19,6 +19,7 @@ import { STATS_DEMANDES_COLUMNS } from "./STATS_DEMANDES_COLUMN";
 import { Filters, Order } from "./types";
 
 const PAGE_SIZE = 30;
+const EXPORT_LIMIT = 1_000_000;
 
 const TableHeader = ({
   page,
@@ -134,16 +135,21 @@ export default () => {
     });
   };
 
+  const getIntentionsStatsQueryParameters = (
+    qLimit: number,
+    qOffset?: number
+  ) => ({
+    ...filters,
+    ...order,
+    offset: qOffset,
+    limit: qLimit,
+  });
+
   const { data, isLoading: isLoading } = client
     .ref("[GET]/intentions/stats")
     .useQuery(
       {
-        query: {
-          ...filters,
-          ...order,
-          offset: page * PAGE_SIZE,
-          limit: PAGE_SIZE,
-        },
+        query: getIntentionsStatsQueryParameters(PAGE_SIZE, page * PAGE_SIZE),
       },
       {
         keepPreviousData: true,
@@ -189,7 +195,7 @@ export default () => {
           onExport={async () => {
             trackEvent("restitution-demandes:export");
             const data = await client.ref("[GET]/intentions/stats").query({
-              query: { ...filters, ...order, limit: 10000000 },
+              query: getIntentionsStatsQueryParameters(EXPORT_LIMIT),
             });
             downloadCsv(
               "demandes_stats_export.csv",


### PR DESCRIPTION
A la base la correction devait être associé à des données manquantes dans l'export depuis la console de l'établissement mais il se trouve que finalement ça fonctionne. 

Est ce que le bug a été corrigé entre-temps ? 

Toujours est-il que pour éviter au maximum les différences entre l'export et l'affichage dans l'app j'ai essayé de faire une méthode qui génère des parametres commun pour la console etablissement et formation