### PR TITLE
fix: Wrong error message in slack

### DIFF
--- a/server/src/modules/core/usecases/redirectDne/redirectDne.route.ts
+++ b/server/src/modules/core/usecases/redirectDne/redirectDne.route.ts
@@ -54,7 +54,14 @@ export const redirectDneRoute = (server: Server) => {
               }
             );
 
-            response.header("set-cookie", cookies).redirect(302, url).send();
+            /**
+             * Return est obligatoire ici pour interrompre l'exécution de la fonction
+             * et empêcher la séquence d'authentification d'être exécutée en entière.
+             */
+            return response
+              .header("set-cookie", cookies)
+              .redirect(302, url)
+              .send();
           }
 
           const { token } = await redirectDne({


### PR DESCRIPTION
Il y a un message d'erreur qui est déclenché dans Slack alors qu'en fait l'utilisateur est déjà redirigé. Le but de la PR est d'interrompre l'exécution de la fonction pour que ce message (et le reste de la fonction) ne soit pas trigger.