### PR TITLE
fix: z-index header

### DIFF
--- a/ui/app/(wrapped)/components/Header.tsx
+++ b/ui/app/(wrapped)/components/Header.tsx
@@ -43,7 +43,7 @@ export const Header = () => {
   return (
     <>
       <VStack
-        zIndex={1}
+        zIndex="popover"
         spacing="0"
         divider={
           <Box
@@ -109,7 +109,7 @@ export const Header = () => {
         position="sticky"
         top={0}
         left={0}
-        zIndex={1000}
+        zIndex="sticky"
         backgroundColor="white"
       >
         <Container maxWidth={"container.xl"} px={0}>


### PR DESCRIPTION
Le but de cette pr est de remettre de l'ordre dans les z-index du header et de faire passer la popover gestion utilisateur devant par dessus la nav fixed

![Screenshot 2024-03-18 at 16 01 09](https://github.com/mission-apprentissage/tjp-pilotage/assets/5200291/7c55e8b5-2842-46ce-960f-0e06a709ce7b)
