### PR TITLE
fix: ordre des nsfs dans le header de la page etablissement

### DIFF
--- a/server/src/modules/data/usecases/getHeaderEtablissement/dependencies/getNsfs.deps.ts
+++ b/server/src/modules/data/usecases/getHeaderEtablissement/dependencies/getNsfs.deps.ts
@@ -63,6 +63,7 @@ export const getNsfs = ({ uai }: { uai: string }) =>
       eb.fn.sum("nbFormations").as("nbFormations"),
     ])
     .groupBy(["codeNsf", "libelleNsf"])
+    .orderBy("nbFormations desc")
     .distinct()
     .$castTo<{ codeNsf: string; libelleNsf: string; nbFormations: number }>()
     .execute()


### PR DESCRIPTION
Modification de l'ordre des nsfs sur la page etablissement pour qu'il soit decroissant en fonction du nb de formations

Avant
![CleanShot 2024-03-21 at 10 06 29](https://github.com/mission-apprentissage/tjp-pilotage/assets/10882002/620de752-1dec-446f-ae14-7756e1b758c3)

Apres
![CleanShot 2024-03-21 at 10 10 57](https://github.com/mission-apprentissage/tjp-pilotage/assets/10882002/7ce8608c-efd3-4e85-8a73-18b130b35bff)
