### PR TITLE
feat: mise en place de l'ordre alphabétique pour les entrées du glossaire

### DIFF
--- a/server/src/modules/glossaire/usecases/getGlossaire/getGlossaire.usecase.ts
+++ b/server/src/modules/glossaire/usecases/getGlossaire/getGlossaire.usecase.ts
@@ -28,7 +28,7 @@ export const getGlossaireFactory =
       database.results as PageObjectResponse[]
     );
 
-    return entries.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+    return entries.sort((a, b) => a.title?.localeCompare(b.title ?? "") ?? 0);
   };
 
 export const getGlossaire = getGlossaireFactory();


### PR DESCRIPTION
Modification de l'ordre d'affichage des entrées glossaire, on passe d'un ordre qui été définie coté notion ( propriété order ) vers un ordre alphabétique.

Avant 
![CleanShot 2024-03-21 at 10 37 44](https://github.com/mission-apprentissage/tjp-pilotage/assets/10882002/f691aab8-b8a0-4690-bdb7-d6f4ba142efc)

Après
![CleanShot 2024-03-21 at 10 33 37](https://github.com/mission-apprentissage/tjp-pilotage/assets/10882002/5579d7df-0d0c-4b5c-a0b8-ed04ec7fcda5)
