### PR TITLE
fix: page etablissement filtre analyse detaillée coté front

### DIFF
--- a/server/src/modules/data/usecases/getAnalyseDetailleeEtablissement/dependencies/getFormations.dep.ts
+++ b/server/src/modules/data/usecases/getAnalyseDetailleeEtablissement/dependencies/getFormations.dep.ts
@@ -5,15 +5,7 @@ import { cleanNull } from "../../../../../utils/noNull";
 import { FormationSchema } from "../getAnalyseDetailleeEtablissement.schema";
 import { getBase } from "./base.dep";
 
-export const getFormations = async ({
-  uai,
-  codeNiveauDiplome,
-  voie,
-}: {
-  uai: string;
-  codeNiveauDiplome?: string[];
-  voie?: string[];
-}) =>
+export const getFormations = async ({ uai }: { uai: string }) =>
   getBase({ uai })
     .select((eb) => [
       sql<string>`CONCAT(
@@ -38,16 +30,6 @@ export const getFormations = async ({
       "libelleFormation asc",
       "libelleDispositif",
     ])
-    .$call((q) => {
-      if (codeNiveauDiplome?.length)
-        q = q.where("dataFormation.codeNiveauDiplome", "in", codeNiveauDiplome);
-
-      if (voie?.length) {
-        q = q.where("formationEtablissement.voie", "in", voie);
-      }
-
-      return q;
-    })
     .$castTo<z.infer<typeof FormationSchema>>()
     .execute()
     .then(cleanNull);

--- a/server/src/modules/data/usecases/getAnalyseDetailleeEtablissement/getAnalyseDetailleeEtablissement.route.ts
+++ b/server/src/modules/data/usecases/getAnalyseDetailleeEtablissement/getAnalyseDetailleeEtablissement.route.ts
@@ -17,10 +17,8 @@ export const getAnalyseDetailleeEtablissementRoute = ({
       ...props,
       handler: async (request, response) => {
         const { uai } = request.params;
-        const filters = request.query;
         const analyseDetaillee = await getAnalyseDetailleeEtablissement({
           uai,
-          ...filters,
         });
         response.status(200).send(analyseDetaillee);
       },

--- a/server/src/modules/data/usecases/getAnalyseDetailleeEtablissement/getAnalyseDetailleeEtablissement.schema.ts
+++ b/server/src/modules/data/usecases/getAnalyseDetailleeEtablissement/getAnalyseDetailleeEtablissement.schema.ts
@@ -84,10 +84,6 @@ export const getAnalyseDetailleeEtablissementSchema = {
   params: z.object({
     uai: z.string(),
   }),
-  querystring: z.object({
-    codeNiveauDiplome: z.array(z.string()).optional(),
-    voie: z.array(voie).optional(),
-  }),
   response: {
     200: z.object({
       etablissement: EtablissementSchema,

--- a/server/src/modules/data/usecases/getAnalyseDetailleeEtablissement/getAnalyseDetailleeEtablissement.usecase.ts
+++ b/server/src/modules/data/usecases/getAnalyseDetailleeEtablissement/getAnalyseDetailleeEtablissement.usecase.ts
@@ -48,11 +48,7 @@ export const getAnalyseDetailleeEtablissementFactory =
       getPositionQuadrant,
     }
   ) =>
-  async (activeFilters: {
-    uai: string;
-    codeNiveauDiplome?: string[];
-    voie?: string[];
-  }) => {
+  async (activeFilters: { uai: string }) => {
     const [
       formations,
       etablissement,

--- a/ui/app/(wrapped)/panorama/etablissement/components/analyse-detaillee/filters/FiltersSection.tsx
+++ b/ui/app/(wrapped)/panorama/etablissement/components/analyse-detaillee/filters/FiltersSection.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text } from "@chakra-ui/react";
+import { Flex, Select, Text } from "@chakra-ui/react";
 import { Voie, VoieEnum } from "shared";
 
 import { Multiselect } from "@/components/Multiselect";
@@ -14,6 +14,13 @@ const extractVoieOptions = (voies?: Voie[]) => {
 
   if (!voies?.length || voies.includes(VoieEnum.apprentissage)) {
     options.push({ value: VoieEnum.apprentissage, label: "Apprentissage" });
+  }
+
+  if (
+    voies?.includes(VoieEnum.scolaire) &&
+    voies?.includes(VoieEnum.apprentissage)
+  ) {
+    options.push({ value: "all", label: "Toutes" });
   }
 
   return options;
@@ -53,17 +60,17 @@ export const FiltersSection = ({
         <Text fontSize={14} fontWeight={400} lineHeight={"24px"}>
           Voie
         </Text>
-        <Multiselect
-          onClose={filterTracker("voie")}
-          width="20rem"
-          variant={"newInput"}
-          onChange={(selected) => handleFilters("voie", selected)}
-          options={extractVoieOptions(filtersData?.voies)}
-          value={filters.voie ?? []}
-          size="md"
+        <Select
+          value={filters.voie?.[0] ?? "all"}
+          onChange={(e) => handleFilters("voie", [e.target.value])}
+          width="24rem"
         >
-          Toutes
-        </Multiselect>
+          {extractVoieOptions(filtersData?.voies).map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </Select>
       </Flex>
     </Flex>
   );

--- a/ui/app/(wrapped)/panorama/etablissement/components/analyse-detaillee/tabs/TabsContent.tsx
+++ b/ui/app/(wrapped)/panorama/etablissement/components/analyse-detaillee/tabs/TabsContent.tsx
@@ -6,6 +6,7 @@ import { FiltersSection } from "../filters/FiltersSection";
 import { useAnalyseDetaillee } from "../hook";
 import { ListeFormations } from "../listeFormations/ListeFormations";
 import { QuadrantSection } from "../quadrant/QuadrantSection";
+import { DisplayTypeEnum } from "./displayTypeEnum";
 
 export const TabsContent = (params: ReturnType<typeof useAnalyseDetaillee>) => {
   const {
@@ -42,14 +43,15 @@ export const TabsContent = (params: ReturnType<typeof useAnalyseDetaillee>) => {
         <GridItem colSpan={6}>
           {feature.etablissementQuadrant ? (
             <>
-              {displayType === "dashboard" ? (
+              {displayType === DisplayTypeEnum.dashboard && (
                 <Dashboard
                   codeRegion={etablissement?.codeRegion}
                   formation={formations?.[offre]}
                   chiffresIJOffre={chiffresIJ?.[offre]}
                   chiffresEntreeOffre={chiffresEntree?.[offre]}
                 />
-              ) : (
+              )}
+              {displayType === DisplayTypeEnum.quadrant && (
                 <QuadrantSection
                   formations={Object.values(formations ?? {})}
                   currentFormation={formations?.[offre]}

--- a/ui/app/(wrapped)/panorama/etablissement/components/analyse-detaillee/tabs/displayTypeEnum.ts
+++ b/ui/app/(wrapped)/panorama/etablissement/components/analyse-detaillee/tabs/displayTypeEnum.ts
@@ -1,0 +1,4 @@
+export enum DisplayTypeEnum {
+  dashboard = "dashboard",
+  quadrant = "quadrant",
+}

--- a/ui/app/(wrapped)/panorama/etablissement/components/analyse-detaillee/types.ts
+++ b/ui/app/(wrapped)/panorama/etablissement/components/analyse-detaillee/types.ts
@@ -1,9 +1,17 @@
+import { voie } from "shared/enum/voieEnum";
+import { z } from "zod";
+
 import { client } from "@/api.client";
 
 export type Query =
   (typeof client.inferArgs)["[GET]/etablissement/:uai/analyse-detaillee"]["query"];
 
-export type Filters = Pick<Query, "codeNiveauDiplome" | "voie">;
+const filtersSchema = z.object({
+  codeNiveauDiplome: z.array(z.string()),
+  voie: z.array(z.enum([...voie.options, "all"] as const)),
+});
+
+export type Filters = z.infer<typeof filtersSchema>;
 export type AnalyseDetaillee =
   (typeof client.infer)["[GET]/etablissement/:uai/analyse-detaillee"];
 export type Formations = AnalyseDetaillee["formations"];


### PR DESCRIPTION
Modification des filtres cotés front de la page établissement. 

Le but n'est plus de filtrer les formations qui soient scolaires ou apprentissage coté serveur mais coté front pour disposer directement de la liste des formations

![CleanShot 2024-04-11 at 16 01 11@2x](https://github.com/mission-apprentissage/tjp-pilotage/assets/10882002/98a6b1cf-a24c-4d1b-8772-a1ea45956c1d)
