### PR TITLE
fix (sso): les délégations perdir ne doivent pas être confrontées au …

### DIFF
--- a/server/src/modules/core/usecases/redirectDne/redirectDne.usecase.ts
+++ b/server/src/modules/core/usecases/redirectDne/redirectDne.usecase.ts
@@ -60,12 +60,8 @@ const extractUaisRep = (userInfo: UserinfoResponse<ExtraUserInfo>) => {
       }) as unknown as Array<string>
     );
 
-    const verifiedDelegations = delegations.filter((del) =>
-      perdirOnUais.includes(del)
-    );
-
-    if (verifiedDelegations.length > 0) {
-      uais.push(...verifiedDelegations);
+    if (delegations.length > 0) {
+      uais.push(...delegations);
     }
   }
   return uais;


### PR DESCRIPTION
…champ FrEduRne

Cf. mail reçu ce matin concernant les délégations : 

Normalement, c’est l’UAI contenu dans la ligne FrEduResDel qui ouvre les droits dans l’application. Cela dépend évidemment de l’implémentation faite par le projet, mais en général, les applications ne font pas de vérification de matching entre ces UAI et ceux d’exercice ou de rattachement de l’agent.

La personne devrait pouvoir accéder à l’application sur le périmètre des UAI contenus dans FrEduResDel.