### PR TITLE
fix(panorama): suppression temporaire du bouton exporter

### DIFF
--- a/ui/app/(wrapped)/intentions/pilotage/components/QuadrantSection.tsx
+++ b/ui/app/(wrapped)/intentions/pilotage/components/QuadrantSection.tsx
@@ -226,6 +226,10 @@ export const QuadrantSection = ({
             </Button>
             <Flex>
               <ExportMenuButton
+                sx={{
+                  display:
+                    "none" /* Le boutton Exporter est désactivé tant qu'il n'y a pas eu l'harmonisation des données */,
+                }}
                 onExportCsv={async () => {
                   if (!formations) return;
                   downloadCsv(

--- a/ui/app/(wrapped)/panorama/components/QuadrantSection.tsx
+++ b/ui/app/(wrapped)/panorama/components/QuadrantSection.tsx
@@ -367,6 +367,10 @@ export const QuadrantSection = ({
                 }`}
               </Button>
               <ExportMenuButton
+                sx={{
+                  display:
+                    "none" /* Le boutton Exporter est désactivé tant qu'il n'y a pas eu l'harmonisation des données */,
+                }}
                 onExportCsv={async () => {
                   if (!filteredFormations) return;
                   trackEvent(`panorama-${segment}:export`);

--- a/ui/components/ExportMenuButton.tsx
+++ b/ui/components/ExportMenuButton.tsx
@@ -3,6 +3,7 @@ import {
   Button,
   Menu,
   MenuButton,
+  MenuButtonProps,
   MenuItem,
   MenuList,
   Spinner,
@@ -30,15 +31,19 @@ const ExportButton = ({
     </MenuItem>
   );
 };
+
+type ExportMenuButtonProps = MenuButtonProps & {
+  onExportCsv?: () => Promise<void>;
+  onExportExcel?: () => Promise<void>;
+  variant?: string;
+};
+
 export const ExportMenuButton = ({
   onExportCsv,
   onExportExcel,
   variant = "ghost",
-}: {
-  onExportCsv?: () => Promise<void>;
-  onExportExcel?: () => Promise<void>;
-  variant?: string;
-}) => {
+  ...rest
+}: ExportMenuButtonProps) => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const handleExportCsv = async () => {
@@ -67,6 +72,7 @@ export const ExportMenuButton = ({
       </Button>
     );
   }
+
   return (
     <Menu gutter={0}>
       <MenuButton
@@ -74,6 +80,7 @@ export const ExportMenuButton = ({
         variant={variant}
         size="md"
         leftIcon={<DownloadIcon />}
+        {...rest}
       >
         Exporter
       </MenuButton>


### PR DESCRIPTION
Suppression temporaire du bouton Exporter

![CleanShot 2024-06-25 at 09 43 37](https://github.com/mission-apprentissage/tjp-pilotage/assets/10882002/8532a026-6f71-4e95-8603-b2fdcfdb3390)
