### PR TITLE
fix (restit-transfo): Affichage de la position quadrant "-" pour les …

### DIFF
--- a/server/src/modules/data/services/getPositionQuadrant.ts
+++ b/server/src/modules/data/services/getPositionQuadrant.ts
@@ -1,12 +1,12 @@
 const PREMIERE_COMMUNE = "1ere_commune";
 const SECONDE_COMMUNE = "2nde_commune";
 
-const Q1 = "Q1";
-const Q2 = "Q2";
-const Q3 = "Q3";
-const Q4 = "Q4";
-const HORS_QUADRANT = "Hors quadrant";
-const UNDEFINED_QUADRANT = "-";
+export const Q1 = "Q1";
+export const Q2 = "Q2";
+export const Q3 = "Q3";
+export const Q4 = "Q4";
+export const HORS_QUADRANT = "Hors quadrant";
+export const UNDEFINED_QUADRANT = "-";
 
 export const getPositionQuadrant = (
   formation: {

--- a/server/src/modules/data/usecases/getDemandesRestitutionIntentions/deps/getDemandesRestitutionIntentions.query.ts
+++ b/server/src/modules/data/usecases/getDemandesRestitutionIntentions/deps/getDemandesRestitutionIntentions.query.ts
@@ -102,6 +102,7 @@ export const getDemandesRestitutionIntentionsQuery = async ({
       "departement.codeDepartement as codeDepartement",
       "academie.libelleAcademie",
       "academie.codeAcademie as codeAcademie",
+      "dataFormation.typeFamille",
       countDifferenceCapaciteScolaire(eb).as("differenceCapaciteScolaire"),
       countDifferenceCapaciteApprentissage(eb).as(
         "differenceCapaciteApprentissage"

--- a/server/src/modules/data/usecases/getDemandesRestitutionIntentions/getDemandesRestitutionIntentions.usecase.ts
+++ b/server/src/modules/data/usecases/getDemandesRestitutionIntentions/getDemandesRestitutionIntentions.usecase.ts
@@ -5,7 +5,10 @@ import { cleanNull } from "../../../../utils/noNull";
 import { RequestUser } from "../../../core/model/User";
 import { getCurrentCampagneQuery } from "../../queries/getCurrentCampagne/getCurrentCampagne.query";
 import { getStatsSortieParRegionsEtNiveauDiplomeQuery } from "../../queries/getStatsSortie/getStatsSortie";
-import { getPositionQuadrant } from "../../services/getPositionQuadrant";
+import {
+  getPositionQuadrant,
+  HORS_QUADRANT,
+} from "../../services/getPositionQuadrant";
 import { getDemandesRestitutionIntentionsQuery } from "./deps/getDemandesRestitutionIntentions.query";
 import { getFilters } from "./deps/getFilters.query";
 import { FiltersSchema } from "./getDemandesRestitutionIntentions.schema";
@@ -47,6 +50,7 @@ const getDemandesRestitutionIntentionsFactory =
             statsSortie && statsSortie[demande.codeRegion ?? ""]
               ? getPositionQuadrant(
                   {
+                    ...demande,
                     tauxInsertion: demande.tauxInsertionRegional,
                     tauxPoursuite: demande.tauxPoursuiteRegional,
                   },
@@ -54,7 +58,7 @@ const getDemandesRestitutionIntentionsFactory =
                     demande.codeNiveauDiplome ?? ""
                   ] || {}
                 )
-              : "Hors quadrant",
+              : HORS_QUADRANT,
         })
       ),
       campagne,

--- a/server/src/modules/data/usecases/getFormationEtablissements/getFormationEtablissements.usecase.ts
+++ b/server/src/modules/data/usecases/getFormationEtablissements/getFormationEtablissements.usecase.ts
@@ -1,6 +1,9 @@
 import { getFormationsRenoveesEnseigneesQuery } from "../../queries/getFormationsRenovees/getFormationsRenovees";
 import { getStatsSortieParRegionsEtNiveauDiplomeQuery } from "../../queries/getStatsSortie/getStatsSortie";
-import { getPositionQuadrant } from "../../services/getPositionQuadrant";
+import {
+  getPositionQuadrant,
+  HORS_QUADRANT,
+} from "../../services/getPositionQuadrant";
 import { dependencies } from "./dependencies";
 
 const getFormationEtablissementsFactory =
@@ -60,7 +63,7 @@ const getFormationEtablissementsFactory =
                   etablissement.codeNiveauDiplome ?? ""
                 ] || {}
               )
-            : "Hors quadrant",
+            : HORS_QUADRANT,
       })),
     };
   };


### PR DESCRIPTION
…1e et 2nd communes


Les classes communes transformées sur la campagne 2023 doivent être sans “position quadrant"