### PR TITLE
chore: mise à jour des dns de recette

### DIFF
--- a/.infra/ansible/env.ini
+++ b/.infra/ansible/env.ini
@@ -10,8 +10,8 @@ env_type=production
 [recette]
 57.128.45.251
 [recette:vars]
-dns_name=orion-recette.inserjeunes.beta.gouv.fr
-host_name=orion-recette
+dns_name=recette-1.orion.inserjeunes.incubateur.net
+host_name=orion-recette-1
 update_sshd_config=true
 git_revision=develop
 env_type=recette
@@ -19,7 +19,7 @@ env_type=recette
 [recette2]
 162.19.124.176
 [recette2:vars]
-dns_name=orion-recette-2.inserjeunes.beta.gouv.fr
+dns_name=recette-2.orion.inserjeunes.incubateur.net
 host_name=orion-recette-2
 update_sshd_config=true
 git_revision=develop

--- a/.infra/ansible/roles/setup/files/app/tools/ssl/certbot/app/entrypoint.sh
+++ b/.infra/ansible/roles/setup/files/app/tools/ssl/certbot/app/entrypoint.sh
@@ -18,7 +18,7 @@ function generate_certificate() {
 
   echo "Generating certificate for domain ${dns_name}..."
   certbot certonly \
-    --email misson.apprentissage.devops@gmail.com \
+    --email contact@inserjeunes.beta.gouv.fr \
     --agree-tos \
     --non-interactive \
     --webroot \

--- a/.infra/ansible/roles/setup/files/app/tools/ssl/generate-certificate.sh
+++ b/.infra/ansible/roles/setup/files/app/tools/ssl/generate-certificate.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if [ ! -f "/opt/pilotage/data/ssl/privkey.pem" ]; then
+  # Arrêter les conteneurs utilisant le port 80
+  running_container=$(docker ps --filter "publish=80" -q)
+  if [ -n "$running_container" ]; then
+    docker stop "$running_container"
+  fi
+
   cd "${SCRIPT_DIR}"
     docker build --tag pilotage_certbot certbot/
     docker run --rm --name pilotage_certbot \
@@ -12,6 +18,11 @@ if [ ! -f "/opt/pilotage/data/ssl/privkey.pem" ]; then
       -v /opt/pilotage/data/ssl:/ssl \
       pilotage_certbot generate "$@"
   cd -
+
+  # Redémarrer le conteneur si nécessaire
+  if [ -n "$running_container" ]; then
+    docker start "$running_container"
+  fi
 else
   echo "Certificat SSL déja généré"
 fi


### PR DESCRIPTION
Mise à jour des dns de recette : 
- recette-1.orion.inserjeunes.incubateur.net
- recette-2.orion.inserjeunes.incubateur.net