### PR TITLE
Fix: faux positif saisie formulaire 

### DIFF
--- a/reverse_proxy/Dockerfile
+++ b/reverse_proxy/Dockerfile
@@ -1,7 +1,7 @@
-ARG NGINX_VERSION="1.20.2"
+ARG NGINX_VERSION="1.25.3"
 FROM nginx:${NGINX_VERSION} as nginxModules
 
-ARG HEADERS_MORE_VERSION="v0.33"
+ARG HEADERS_MORE_VERSION="v0.37"
 
 RUN set -eux; \
     apt-get update; \
@@ -14,9 +14,9 @@ RUN set -eux; \
     libcurl4-gnutls-dev \
     libgeoip-dev \
     liblua5.3-dev \
-    libpcre++-dev \
     libtool \
     libxml2-dev \
+    libpcre3-dev \
     make \
     ruby \
     pkg-config \
@@ -38,10 +38,9 @@ RUN set -eux; \
     cp objs/ngx_http_headers_more_filter_module.so /etc/nginx/modules/;
 
 
-FROM owasp/modsecurity-crs:3.3.2-nginx
+FROM owasp/modsecurity-crs:3.3.5-nginx-202401080101
 
-RUN apt-get update \
-    && apt-get install -y logrotate
+RUN apt-get update && apt-get install -y logrotate
 
 COPY --from=nginxModules /etc/nginx/modules/ngx_http_headers_more_filter_module.so /etc/nginx/modules/ngx_http_headers_more_filter_module.so
 

--- a/reverse_proxy/app/nginx/owasp-crs/rules/REQUEST-949-BLOCKING-EVALUATION.conf
+++ b/reverse_proxy/app/nginx/owasp-crs/rules/REQUEST-949-BLOCKING-EVALUATION.conf
@@ -1,0 +1,15 @@
+SecAction \
+ "id:900110,\
+  phase:1,\
+  nolog,\
+  pass,\
+  t:none,\
+  setvar:tx.inbound_anomaly_score_threshold=40"
+
+SecAction \
+ "id:900111,\
+  phase:1,\
+  nolog,\
+  pass,\
+  t:none,\
+  setvar:tx.outbound_anomaly_score_threshold=40"

--- a/ui/package.json
+++ b/ui/package.json
@@ -35,7 +35,7 @@
     "framer-motion": "^10.9.1",
     "iframe-resizer": "^4.4.0",
     "maplibre-gl": "^4.1.0",
-    "next": "14.1.3",
+    "next": "^14.2.14",
     "next-plausible": "^3.7.2",
     "notion-client": "^6.16.0",
     "qs": "^6.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3946,10 +3946,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:14.1.3":
-  version: 14.1.3
-  resolution: "@next/env@npm:14.1.3"
-  checksum: 1645d801acc5c642c57205c354f39d0b95d5641613a0d6e2aff1ab3e7bd34402953e10246484b405086961b91baf044baf0b7a510f020a68427b63f6093bca90
+"@next/env@npm:14.2.14":
+  version: 14.2.14
+  resolution: "@next/env@npm:14.2.14"
+  checksum: ebbe2ea6b79043dced54ccb670746a60db6522b3e6e73aa30b95ab4af0de491efab6562cdbb57754647e80e6b6f8242f161beabb36b875654b733f103df5c041
   languageName: node
   linkType: hard
 
@@ -3962,65 +3962,65 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-arm64@npm:14.1.3":
-  version: 14.1.3
-  resolution: "@next/swc-darwin-arm64@npm:14.1.3"
+"@next/swc-darwin-arm64@npm:14.2.14":
+  version: 14.2.14
+  resolution: "@next/swc-darwin-arm64@npm:14.2.14"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-x64@npm:14.1.3":
-  version: 14.1.3
-  resolution: "@next/swc-darwin-x64@npm:14.1.3"
+"@next/swc-darwin-x64@npm:14.2.14":
+  version: 14.2.14
+  resolution: "@next/swc-darwin-x64@npm:14.2.14"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-gnu@npm:14.1.3":
-  version: 14.1.3
-  resolution: "@next/swc-linux-arm64-gnu@npm:14.1.3"
+"@next/swc-linux-arm64-gnu@npm:14.2.14":
+  version: 14.2.14
+  resolution: "@next/swc-linux-arm64-gnu@npm:14.2.14"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-musl@npm:14.1.3":
-  version: 14.1.3
-  resolution: "@next/swc-linux-arm64-musl@npm:14.1.3"
+"@next/swc-linux-arm64-musl@npm:14.2.14":
+  version: 14.2.14
+  resolution: "@next/swc-linux-arm64-musl@npm:14.2.14"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-gnu@npm:14.1.3":
-  version: 14.1.3
-  resolution: "@next/swc-linux-x64-gnu@npm:14.1.3"
+"@next/swc-linux-x64-gnu@npm:14.2.14":
+  version: 14.2.14
+  resolution: "@next/swc-linux-x64-gnu@npm:14.2.14"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-musl@npm:14.1.3":
-  version: 14.1.3
-  resolution: "@next/swc-linux-x64-musl@npm:14.1.3"
+"@next/swc-linux-x64-musl@npm:14.2.14":
+  version: 14.2.14
+  resolution: "@next/swc-linux-x64-musl@npm:14.2.14"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-win32-arm64-msvc@npm:14.1.3":
-  version: 14.1.3
-  resolution: "@next/swc-win32-arm64-msvc@npm:14.1.3"
+"@next/swc-win32-arm64-msvc@npm:14.2.14":
+  version: 14.2.14
+  resolution: "@next/swc-win32-arm64-msvc@npm:14.2.14"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-win32-ia32-msvc@npm:14.1.3":
-  version: 14.1.3
-  resolution: "@next/swc-win32-ia32-msvc@npm:14.1.3"
+"@next/swc-win32-ia32-msvc@npm:14.2.14":
+  version: 14.2.14
+  resolution: "@next/swc-win32-ia32-msvc@npm:14.2.14"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@next/swc-win32-x64-msvc@npm:14.1.3":
-  version: 14.1.3
-  resolution: "@next/swc-win32-x64-msvc@npm:14.1.3"
+"@next/swc-win32-x64-msvc@npm:14.2.14":
+  version: 14.2.14
+  resolution: "@next/swc-win32-x64-msvc@npm:14.2.14"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -5759,12 +5759,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/helpers@npm:0.5.2":
-  version: 0.5.2
-  resolution: "@swc/helpers@npm:0.5.2"
+"@swc/counter@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "@swc/counter@npm:0.1.3"
+  checksum: df8f9cfba9904d3d60f511664c70d23bb323b3a0803ec9890f60133954173047ba9bdeabce28cd70ba89ccd3fd6c71c7b0bd58be85f611e1ffbe5d5c18616598
+  languageName: node
+  linkType: hard
+
+"@swc/helpers@npm:0.5.5":
+  version: 0.5.5
+  resolution: "@swc/helpers@npm:0.5.5"
   dependencies:
+    "@swc/counter": ^0.1.3
     tslib: ^2.4.0
-  checksum: 51d7e3d8bd56818c49d6bfbd715f0dbeedc13cf723af41166e45c03e37f109336bbcb57a1f2020f4015957721aeb21e1a7fff281233d797ff7d3dd1f447fa258
+  checksum: d4f207b191e54b29460804ddf2984ba6ece1d679a0b2f6a9c765dcf27bba92c5769e7965668a4546fb9f1021eaf0ff9be4bf5c235ce12adcd65acdfe77187d11
   languageName: node
   linkType: hard
 
@@ -16817,21 +16825,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:14.1.3":
-  version: 14.1.3
-  resolution: "next@npm:14.1.3"
+"next@npm:^14.2.14":
+  version: 14.2.14
+  resolution: "next@npm:14.2.14"
   dependencies:
-    "@next/env": 14.1.3
-    "@next/swc-darwin-arm64": 14.1.3
-    "@next/swc-darwin-x64": 14.1.3
-    "@next/swc-linux-arm64-gnu": 14.1.3
-    "@next/swc-linux-arm64-musl": 14.1.3
-    "@next/swc-linux-x64-gnu": 14.1.3
-    "@next/swc-linux-x64-musl": 14.1.3
-    "@next/swc-win32-arm64-msvc": 14.1.3
-    "@next/swc-win32-ia32-msvc": 14.1.3
-    "@next/swc-win32-x64-msvc": 14.1.3
-    "@swc/helpers": 0.5.2
+    "@next/env": 14.2.14
+    "@next/swc-darwin-arm64": 14.2.14
+    "@next/swc-darwin-x64": 14.2.14
+    "@next/swc-linux-arm64-gnu": 14.2.14
+    "@next/swc-linux-arm64-musl": 14.2.14
+    "@next/swc-linux-x64-gnu": 14.2.14
+    "@next/swc-linux-x64-musl": 14.2.14
+    "@next/swc-win32-arm64-msvc": 14.2.14
+    "@next/swc-win32-ia32-msvc": 14.2.14
+    "@next/swc-win32-x64-msvc": 14.2.14
+    "@swc/helpers": 0.5.5
     busboy: 1.6.0
     caniuse-lite: ^1.0.30001579
     graceful-fs: ^4.2.11
@@ -16839,6 +16847,7 @@ __metadata:
     styled-jsx: 5.1.1
   peerDependencies:
     "@opentelemetry/api": ^1.1.0
+    "@playwright/test": ^1.41.2
     react: ^18.2.0
     react-dom: ^18.2.0
     sass: ^1.3.0
@@ -16864,11 +16873,13 @@ __metadata:
   peerDependenciesMeta:
     "@opentelemetry/api":
       optional: true
+    "@playwright/test":
+      optional: true
     sass:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: 179a5dfd27a3ac900c0c229c523793cf28c3972cf87ec9ce7b68ead8fc2b8cd3b9c0538bba1b42d3351462ffe890b964c869e081da76c3bed29826e7eae4d7a4
+  checksum: 0ecccc7009f5a890408c056ab5d8beabe798fe4049dc972ad8e1da83dd46eb242b623167e46983ad1910866745ba6176dba1b18e0e4dd4d0ee60b4f49b117d6b
   languageName: node
   linkType: hard
 
@@ -22041,7 +22052,7 @@ __metadata:
     framer-motion: ^10.9.1
     iframe-resizer: ^4.4.0
     maplibre-gl: ^4.1.0
-    next: 14.1.3
+    next: ^14.2.14
     next-plausible: ^3.7.2
     notion-client: ^6.16.0
     qs: ^6.11.1


### PR DESCRIPTION
Il y avait des triggers de faux positifs de Modsecurity lors de la saisie de commentaires pour les demandes / intentions et toute autre saisie de nos utilisateurs. J'ai corrigé la règle pour que le trigger soit un peu moins élevé. 

- Passage du trigger à 40 au lieu 5

- Mise à jour de modsecurity dans la version : 4.7.0
- Mise à jour de nginx dans la version : 1.27.2
- Mise à jour de NextJS dans la version 14.2.14