### PR TITLE
feat(gestion-demandes): autoriser les admin à modifier les demandes d…

### DIFF
--- a/server/src/modules/demandes/usecases/submitDemandesStatut/submitDemandesStatut.usecase.ts
+++ b/server/src/modules/demandes/usecases/submitDemandesStatut/submitDemandesStatut.usecase.ts
@@ -1,11 +1,14 @@
 import * as Boom from "@hapi/boom";
-import { getPermissionScope, guardScope } from "shared";
+import { getPermissionScope, guardScope, isAdmin } from "shared";
+import { CampagneStatutEnum } from "shared/enum/campagneStatutEnum";
 import type { DemandeStatutType } from "shared/enum/demandeStatutEnum";
+import { DemandeStatutEnum  } from "shared/enum/demandeStatutEnum";
 import { PermissionEnum } from "shared/enum/permissionEnum";
 import type { submitDemandesStatutSchema } from "shared/routes/schemas/post.demandes.statut.submit.schema";
 import type { z } from "zod";
 
 import type { RequestUser } from "@/modules/core/model/User";
+import { findOneCampagneQuery } from "@/modules/demandes/repositories/findOneCampagne.query";
 import { findOneDemandeQuery } from "@/modules/demandes/repositories/findOneDemande.query";
 import logger from '@/services/logger';
 import { inject } from "@/utils/inject";
@@ -13,10 +16,12 @@ import { inject } from "@/utils/inject";
 import { updateChangementsStatutAndDemandesWithHistory } from './deps/updateChangementsStatutAndDemandesWithHistory.dep';
 
 type Demandes = z.infer<typeof submitDemandesStatutSchema.body>["demandes"];
+const NON_EDITABLE_STATUS: DemandeStatutType[] = [DemandeStatutEnum["demande validée"], DemandeStatutEnum["refusée"]];
 
 export const [submitDemandesStatutUsecase, submitDemandesStatutFactory] = inject(
   {
     findOneDemandeQuery,
+    findOneCampagneQuery,
     updateChangementsStatutAndDemandesWithHistory
   },
   (deps) =>
@@ -43,14 +48,66 @@ export const [submitDemandesStatutUsecase, submitDemandesStatutFactory] = inject
           );
           throw Boom.notFound("Demande non trouvée en base");
         }
+        const campangeData = await deps.findOneCampagneQuery({ id: demandeData.campagneId});
+        if (!campangeData) {
+          logger.error(
+            {
+              statut,
+              user
+            },
+            "[SUBMIT_DEMANDES_STATUT] Campagne non trouvée en base"
+          );
+          throw Boom.notFound("Campagne liée à la demande non trouvée en base");
+        }
 
         const isAllowed = guardScope(scope, {
           région: () => user.codeRegion === demandeData.codeRegion,
           national: () => true,
         });
+
+        const canEditDemandeInCampagne = campangeData.statut === CampagneStatutEnum["en cours"] || isAdmin({ user });
+        const canEditDemande = demandeData.statut &&
+          !NON_EDITABLE_STATUS.includes(demandeData.statut as DemandeStatutType);
+
         if (!isAllowed) {
-          throw Boom.forbidden();
+          logger.error(
+            {
+              user,
+              demande: demandeData.numero,
+              scope
+            },
+            "[SUBMIT_DEMANDES_STATUT] Permission refusée pour modifier la demande"
+          );
+          throw Boom.forbidden("Vous n'avez pas la permission de modifier cette demande.");
         }
+
+        if (!canEditDemandeInCampagne) {
+          logger.error(
+            {
+              user,
+              demande: demandeData.numero,
+              campagne: campangeData.id,
+              scope
+            },
+            "[SUBMIT_DEMANDES_STATUT] L'utilisateur n'a pas les droits nécessaires pour modifier le statut de la demande"
+          );
+          throw Boom.forbidden("Vous n'avez pas les droits nécessaires pour modifier une demande en dehors d'une campagne en cours.");
+        }
+
+        if (!canEditDemande) {
+          logger.error(
+            {
+              user,
+              demande: demandeData.numero,
+              statut: demandeData.statut,
+              campagne: campangeData.id,
+              scope
+            },
+            "[SUBMIT_DEMANDES_STATUT] Impossible de modifier une demande avec ce statut"
+          );
+          throw Boom.forbidden(`Une demande avec le statut "${NON_EDITABLE_STATUS.join("\", \"")}" ne peut pas être modifiée. Veuillez effectuer une correction.`);
+        }
+
         return demandeData;
       }));
 

--- a/ui/app/(wrapped)/demandes/utils/__tests__/permissionsOldDemandeUtils.test.ts
+++ b/ui/app/(wrapped)/demandes/utils/__tests__/permissionsOldDemandeUtils.test.ts
@@ -267,7 +267,7 @@ describe("ui > app > (wrapped) > demandes > utils > permissionsDemandeUtils", ()
     fixture.when.canImportDemande();
     fixture.then.verifierCanNotImport();
 
-    fixture.when.canEditDemande( );
+    fixture.when.canEditDemande();
     fixture.then.verifierCanNotEdit();
 
     fixture.when.canCreateDemande();
@@ -285,41 +285,41 @@ describe("ui > app > (wrapped) > demandes > utils > permissionsDemandeUtils", ()
     fixture.given.campagne2024();
     fixture.given.demandeEditable();
 
-    fixture.when.canEditDemande( );
+    fixture.when.canEditDemande();
     fixture.then.verifierCanEdit();
 
     fixture.when.canDeleteDemande();
     fixture.then.verifierCanDelete();
   });
 
-  it("Un utilisateur national ne doit pas pouvoir modifier une demande non éditable", () => {
+  it("Un utilisateur national doit pouvoir modifier une demande non éditable", () => {
     fixture.given.utilisateurNational();
     fixture.given.campagne2024();
     fixture.given.demandeNonEditable();
 
-    fixture.when.canEditDemande( );
-    fixture.then.verifierCanNotEdit();
+    fixture.when.canEditDemande();
+    fixture.then.verifierCanEdit();
   });
 
-  it("Un utilisateur national ne doit pas pouvoir créer ou modifier une demande pendant une campagne terminée", () => {
+  it("Un utilisateur national ne doit pas pouvoir créer, mais doit pouvoir modifier une demande pendant une campagne terminée", () => {
     fixture.given.utilisateurNational();
     fixture.given.campagne2023Terminee();
     fixture.given.demandeEditable();
 
-    fixture.when.canEditDemande( );
-    fixture.then.verifierCanNotEdit();
+    fixture.when.canEditDemande();
+    fixture.then.verifierCanEdit();
 
     fixture.when.canCreateDemande();
     fixture.then.verifierCanNotCreate();
   });
 
-  it("Un utilisateur national ne doit pas pouvoir créer ou modifier une demande pendant une campagne en attente", () => {
+  it("Un utilisateur national ne doit pas pouvoir créer, mais doit pouvoir modifier une demande pendant une campagne en attente", () => {
     fixture.given.utilisateurNational();
     fixture.given.campagne2025EnAttente();
     fixture.given.demandeEditable();
 
-    fixture.when.canEditDemande( );
-    fixture.then.verifierCanNotEdit();
+    fixture.when.canEditDemande();
+    fixture.then.verifierCanEdit();
 
     fixture.when.canCreateDemande();
     fixture.then.verifierCanNotCreate();
@@ -330,7 +330,7 @@ describe("ui > app > (wrapped) > demandes > utils > permissionsDemandeUtils", ()
     fixture.given.campagne2024();
     fixture.given.demandeEditable();
 
-    fixture.when.canEditDemande( );
+    fixture.when.canEditDemande();
     fixture.then.verifierCanEdit();
   });
 
@@ -347,7 +347,7 @@ describe("ui > app > (wrapped) > demandes > utils > permissionsDemandeUtils", ()
     fixture.given.campagne2024();
     fixture.given.demandeEditable();
 
-    fixture.when.canEditDemande( );
+    fixture.when.canEditDemande();
     fixture.then.verifierCanEdit();
 
     fixture.when.canCreateDemande();
@@ -362,7 +362,7 @@ describe("ui > app > (wrapped) > demandes > utils > permissionsDemandeUtils", ()
     fixture.given.campagne2024();
     fixture.given.demandeEditable();
 
-    fixture.when.canEditDemande( );
+    fixture.when.canEditDemande();
     fixture.then.verifierCanEdit();
   });
 
@@ -371,7 +371,7 @@ describe("ui > app > (wrapped) > demandes > utils > permissionsDemandeUtils", ()
     fixture.given.campagne2024();
 
     fixture.given.demandeNonEditable();
-    fixture.when.canEditDemande( );
+    fixture.when.canEditDemande();
     fixture.then.verifierCanNotEdit();
   });
 
@@ -380,7 +380,7 @@ describe("ui > app > (wrapped) > demandes > utils > permissionsDemandeUtils", ()
     fixture.given.campagne2024();
 
     fixture.given.demandeEditable();
-    fixture.when.canEditDemande( );
+    fixture.when.canEditDemande();
     fixture.then.verifierCanNotEdit();
   });
 
@@ -389,7 +389,7 @@ describe("ui > app > (wrapped) > demandes > utils > permissionsDemandeUtils", ()
     fixture.given.campagne2024();
 
     fixture.given.demandeEditable();
-    fixture.when.canEditDemande( );
+    fixture.when.canEditDemande();
     fixture.then.verifierCanNotEdit();
   });
 
@@ -498,9 +498,8 @@ describe("ui > app > (wrapped) > demandes > utils > permissionsDemandeUtils", ()
     fixture.given.campagne2024();
     fixture.given.demandeEditable();
 
-    fixture.when.canEditDemande( );
+    fixture.when.canEditDemande();
 
     fixture.then.verifierCanEdit();
   });
-
 });

--- a/ui/app/(wrapped)/demandes/utils/permissionsDemandeUtils.ts
+++ b/ui/app/(wrapped)/demandes/utils/permissionsDemandeUtils.ts
@@ -115,6 +115,10 @@ const canEditOldDemande = ({
   demande: Demande,
   user?: UserType
 }): boolean => {
+  if (isAdmin({ user }) &&
+      !isStatutDemandeValidee(demande.statut) &&
+      !isStatutRefusee(demande.statut)) return true;
+
   if(feature.saisieDisabled) return false;
   if(!demande.canEdit) return false;
   if(!isCampagneEnCours(demande?.campagne)) return false;


### PR DESCRIPTION
…e campagnes passées
<img width="916" alt="Screenshot 2025-06-10 at 11 16 41" src="https://github.com/user-attachments/assets/167e815a-2466-40e9-8158-5b28d1c5d386" />

J'ai mis quelques gardes : 
- Autorisés uniquement pour les admins
- Messages d'erreurs explicatifs au cas où
- Pas possible pour les demandes validées / refusées (même pour les admins)